### PR TITLE
Fix loadCats() being called every time the activity is recreated

### DIFF
--- a/app/src/main/java/com/gunaya/demo/demomeow/presentation/MainActivity.kt
+++ b/app/src/main/java/com/gunaya/demo/demomeow/presentation/MainActivity.kt
@@ -46,7 +46,5 @@ class MainActivity : AppCompatActivity() {
         viewModel.showError.observe(this, Observer { showError ->
             Toast.makeText(this, showError, Toast.LENGTH_SHORT).show()
         })
-        // The observers are set, we can now ask API to load a data list
-        viewModel.loadCats()
     }
 }

--- a/app/src/main/java/com/gunaya/demo/demomeow/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/gunaya/demo/demomeow/presentation/MainViewModel.kt
@@ -19,6 +19,10 @@ class MainViewModel(private val catRepository: CatRepository) : ViewModel(), Cor
     val catsList = MutableLiveData<List<Cat>>()
     val showError = SingleLiveEvent<String>()
 
+    init {
+        loadCats()
+    }
+
     fun loadCats() {
         // Show progressBar during the operation on the MAIN (default) thread
         showLoading.value = true


### PR DESCRIPTION
Calling loadCats() inside the activity onCreate() is problematic because every time the activity is recreated e.g. screen rotation a new API call is made. This removes the purpose of ViewModel to retain informations in lifecycle events.
To fix this, init{} is a good place to make this call as it will only happen on viewModel creation (that only happens once because the ViewModel is being injected).